### PR TITLE
Uninitialized length fix

### DIFF
--- a/lib/Locale/Maketext/Extract.pm
+++ b/lib/Locale/Maketext/Extract.pm
@@ -590,7 +590,13 @@ sub normalize_space {
 =cut
 
 sub msgids    { sort keys %{ $_[0]{lexicon} } }
-sub has_msgid { length $_[0]->msgstr( $_[1] ) }
+sub has_msgid {
+    if ($_[0]->msgstr( $_[1] )) {
+        return length $_[0]->msgstr( $_[1] );
+    } else {
+        return 0;
+    }   
+}
 
 sub msg_positions {
     my ( $self, $msgid ) = @_;


### PR DESCRIPTION
Copy/pasting comment from commit:

```
In some cases I got following waring:

WRITING PO FILE : messages.po
Use of uninitialized value in length at /usr/local/share/perl/5.10.1/Locale/Maketext/Extract.pm line 593.
DONE

So I've patched the file to prevent such output.
```
