### PR TITLE
Two tiny changes to xgettext.pl

### DIFF
--- a/lib/Locale/Maketext/Extract/Run.pm
+++ b/lib/Locale/Maketext/Extract/Run.pm
@@ -70,9 +70,11 @@ sub run {
                wanted => sub {
                    if (-d) {
                        $File::Find::prune
-                           = /^(\.svn|blib|autogen|var|m4|local|CVS)$/;
+                           = /^(\.svn|blib|autogen|var|m4|local|CVS|\.git)$/;
                        return;
                    }
+                   # Only extract from non-binary, normal files
+                   return unless (-f or -s) and -T;
                    return
                        if (/\.po$|\.bak$|~|,D|,B$/i)
                        || (/^[\.#]/);


### PR DESCRIPTION
Hi! Recently at Socialtext we've had to run xgettext.pl on a Git checkout, so I've added .git/ to the list of directories to be pruned.

Also, since the directory contains unix pipe-files, it was necessary to add the (-f or -s) check to limit to plain/symlink files, as well as the -T to avoid wasting cycles on big .ttf files.

No tests yet (I know, I know...) - hope the changes still make sense though. :-)
