### PR TITLE
Better plugin loading with Class::Load

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -26,6 +26,7 @@ recommends:
   YAML: 0.66
   YAML::Loader: 0.66
 requires:
+  Class::Load: 0.06
   Locale::Maketext: 1.17
   perl: 5.005
 resources:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,7 @@ perl_version '5.005';
 all_from 'lib/Locale/Maketext/Lexicon.pm';
 install_script 'script/xgettext.pl';
 requires 'Locale::Maketext'       => '1.17';
+requires 'Class::Load'            => '0.06';
 recommends 'Template'             => '2.20';
 recommends 'Template::Constants'  => '2.75';
 recommends 'YAML'                 => '0.66';

--- a/lib/Locale/Maketext/Extract.pm
+++ b/lib/Locale/Maketext/Extract.pm
@@ -3,6 +3,8 @@ $Locale::Maketext::Extract::VERSION = '0.38';
 
 use strict;
 use Locale::Maketext::Lexicon();
+use Class::Load ();
+
 
 =head1 NAME
 
@@ -327,14 +329,13 @@ sub plugins {
 
         foreach my $name ( keys %params ) {
             my $plugin_class = $Known_Plugins{$name} || $name;
-            my $filename = $plugin_class . '.pm';
-            $filename =~ s/::/\//g;
-            local $@;
-            eval {
-                require $filename && 1;
-                1;
-            } or next;
-            push @plugins, $plugin_class->new( $params{$name} );
+            my ($status, $err) = Class::Load::try_load_class($plugin_class);
+            if ($status == 1) {
+                push @plugins, $plugin_class->new( $params{$name} );
+            } else {
+                print STDERR "$err\n"
+                    if $self->{verbose};
+            }
         }
         $self->{plugins} = \@plugins;
     }


### PR DESCRIPTION
- Do not try to load plugin that was already loaded.
  - Since I want to write extractor in my-xgettext.pl
- Display reason if can't load plugin under the verbose mode.
  - I can't find a plugin issue without this patch.
