### PR TITLE
Add ability to parse Mojolicious syntax for TT messages

### DIFF
--- a/lib/Locale/Maketext/Extract/Plugin/TT2.pm
+++ b/lib/Locale/Maketext/Extract/Plugin/TT2.pm
@@ -355,7 +355,8 @@ sub filter {
     $name = $name->[0];
     return ''
         unless $name eq "'l'"
-            or $name eq "'loc'";
+            or $name eq "'loc'"
+            or $name eq "'c.l'";
     if ( strip_quotes($block) ) {
         $block =~ s/\\\\/\\/g;
         $args = join_args( $class->args($args) );

--- a/lib/Locale/Maketext/Extract/Plugin/TT2.pm
+++ b/lib/Locale/Maketext/Extract/Plugin/TT2.pm
@@ -278,9 +278,24 @@ sub ident {
             $name .= join_args($args);
             push( @dotted, $name );
         }
+
+        my $got_i18n = 0;
+
+        # Classic TT syntax [% l('...') %] or [% loc('....') %]
         if ( $first_literal
              && ( $ident->[0] eq "'l'" or $ident->[0] eq "'loc'" ) )
         {
+           $got_i18n = 1;
+        }
+
+        # Mojolicious TT syntax [% c.l('...') %]
+        elsif ($ident->[0] eq "'c'" && $ident->[2] eq "'l'")
+        {
+           $got_i18n = 1;
+           splice(@$ident, 0, 2);
+        }
+
+        if ($got_i18n) {
             my $string = shift @{ $ident->[1] };
             strip_quotes($string);
             $string =~ s/\\\\/\\/g;

--- a/lib/Locale/Maketext/Extract/Plugin/TT2.pm
+++ b/lib/Locale/Maketext/Extract/Plugin/TT2.pm
@@ -38,6 +38,12 @@ Valid formats are:
 
 =item [% l('string',args) %]
 
+=item [% c.l('string') %]
+
+Also all the above combinations with C<c.> prepended should work
+correctly. This is the default syntax when using TT templates
+with L<Mojolicious>.
+
 =back
 
 l and loc are interchangeable.

--- a/t/5-extract.t
+++ b/t/5-extract.t
@@ -1,7 +1,7 @@
 #! /usr/bin/perl -w
 use lib '../lib';
 use strict;
-use Test::More tests => 76;
+use Test::More tests => 77;
 
 use_ok('Locale::Maketext::Extract');
 my $Ext = Locale::Maketext::Extract->new();
@@ -957,6 +957,11 @@ __TT__
 msgid "string"
 msgstr ""
 __EXAMPLE__
+
+    extract_ok(
+        q([% c.l('Hello, world!') %]) => "Hello, world!",
+        "Mojolicious syntax is supported correctly",
+    );
 
     #### END TT TESTS ############
 }

--- a/t/5-extract.t
+++ b/t/5-extract.t
@@ -1,7 +1,7 @@
 #! /usr/bin/perl -w
 use lib '../lib';
 use strict;
-use Test::More tests => 77;
+use Test::More tests => 78;
 
 use_ok('Locale::Maketext::Extract');
 my $Ext = Locale::Maketext::Extract->new();
@@ -962,6 +962,14 @@ __EXAMPLE__
         q([% c.l('Hello, world!') %]) => "Hello, world!",
         "Mojolicious syntax is supported correctly",
     );
+
+    write_po_ok( <<'__TT__' => <<'__EXAMPLE__', 'Mojolicious and filter syntax' );
+[% 'my string' | c.l %]
+__TT__
+#: :1
+msgid "my string"
+msgstr ""
+__EXAMPLE__
 
     #### END TT TESTS ############
 }


### PR DESCRIPTION
Hi Clinton,

Thanks for maintaining this distribution. It's been a blessing for our i18n work.

I have added the ability to parse Mojolicious syntax for i18n strings in the TT2 plugin,
so now the plugin detects also strings like `[% c.l('...') %]`.

I have added a test case to t/5-extract.t and verified that all the existing tests are also passing.
Would be cool to have it out on CPAN :)
## 

Cosimo
