### PR TITLE
Support l() function name in Extract::Plugin::Perl.

### DIFF
--- a/lib/Locale/Maketext/Extract.pm
+++ b/lib/Locale/Maketext/Extract.pm
@@ -78,7 +78,7 @@ Following formats of input files are supported:
 =item Perl source files  (plugin: perl)
 
 Valid localization function names are: C<translate>, C<maketext>,
-C<gettext>, C<loc>, C<x>, C<_> and C<__>.
+C<gettext>, C<l>, C<loc>, C<x>, C<_> and C<__>.
 
 For a slightly more accurate, but much slower Perl parser, you can  use the PPI
 plugin. This does not have a short name (like C<perl>), but must be specified

--- a/lib/Locale/Maketext/Extract/Plugin/PPI.pm
+++ b/lib/Locale/Maketext/Extract/Plugin/PPI.pm
@@ -40,6 +40,8 @@ Valid localization function names are:
 
 =item gettext
 
+=item l
+
 =item loc
 
 =item x
@@ -68,7 +70,7 @@ sub file_types {
     return qw( pm pl cgi );
 }
 
-my %subnames = map { $_ => 1 } qw (translate maketext gettext loc x __);
+my %subnames = map { $_ => 1 } qw (translate maketext gettext l loc x __);
 
 #===================================
 sub extract {

--- a/lib/Locale/Maketext/Extract/Plugin/Perl.pm
+++ b/lib/Locale/Maketext/Extract/Plugin/Perl.pm
@@ -42,6 +42,8 @@ Valid localization function names are:
 
 =item gettext
 
+=item l
+
 =item loc
 
 =item x
@@ -99,7 +101,7 @@ PARSER: {
 
         # various ways to spell the localization function
         $state == NUL
-            && m/\b(translate|maketext|gettext|__?|loc(?:ali[sz]e)?|x)/gc
+            && m/\b(translate|maketext|gettext|__?|loc(?:ali[sz]e)?|l|x)/gc
             && do { $state = BEG; redo };
         $state == BEG && m/^([\s\t\n]*)/gc && redo;
 

--- a/t/51-perlextract.t
+++ b/t/51-perlextract.t
@@ -1,7 +1,7 @@
 #! /usr/bin/perl -w
 use lib '../lib';
 use strict;
-use Test::More tests => 87;
+use Test::More tests => 89;
 
 use_ok('Locale::Maketext::Extract');
 my $Ext = Locale::Maketext::Extract->new(
@@ -66,6 +66,9 @@ sub run_tests {
                 $prefix . 'Normalized \\\\ in q' );
     extract_ok( q(_("foo\bar")) => "foo\bar",
                 $prefix . 'Interpolated \b in qq' );
+
+    extract_ok( q(l( 'foo "bar" baz' );) => 'foo "bar" baz',
+                $prefix . 'Recognizes l() as a localization function' );
 
     extract_ok( q([% loc( 'foo "bar" baz' ) %]) => 'foo "bar" baz',
                 $prefix . 'Escaped double quote in text' );

--- a/t/51-perlextract.t
+++ b/t/51-perlextract.t
@@ -4,7 +4,8 @@ use strict;
 use Test::More tests => 87;
 
 use_ok('Locale::Maketext::Extract');
-my $Ext = Locale::Maketext::Extract->new();
+my $Ext = Locale::Maketext::Extract->new(
+            plugins => { 'Locale::Maketext::Extract::Plugin::Perl' => '*' } );
 
 # Standard Perl parser
 run_tests('perl - ');


### PR DESCRIPTION
Hi Clint,

This is the first of three pull request regarding adding HAML support to Locale::Maketext::Lexicon. It adds the name "l" as a valid translation function to E::P::Perl and E::P::PPI. This is to done mainly to support the fact that the Mojolicious MVC framework imports this function into its templates, both the default EP ones and HAML ones, if you choose to use HAML.

In the next pull request, the next E::P::Haml plugin will make use of this functionality.

Regards,
Calum
