### PR TITLE
Remove spurious "next" in lexicon_get_glob()

### DIFF
--- a/lib/Locale/Maketext/Lexicon.pm
+++ b/lib/Locale/Maketext/Lexicon.pm
@@ -462,7 +462,6 @@ sub lexicon_get_glob {
             while ( my ( $pkg, $filename ) = caller( $level++ ) ) {
                 next unless $pkg eq $package;
                 next unless -e $filename;
-                next;
 
                 $fh->open($filename) or die "Can't open $filename: $!";
                 last;


### PR DESCRIPTION
When faced with a `*DATA` file glob, `lexicon_get_glob()` will:

  1. Walk the call stack, looking for the package that contains that `*DATA` glob.
  2. Open that module's source file.
  3. Skip up to and including the `__DATA__` line.
  4. Read the rest of the input as the content to parse.

... Except that step 1 doesn't work. Due to an unqualified `next` statement, it was just basically running an empty loop.

The result was that the below would just never work:

    use Locale::Maketext::Lexicon( Gettext => \*DATA );

This made me sad.